### PR TITLE
Pull `clojure-tools` as part of babashka install

### DIFF
--- a/internal/bb.sh.tpl
+++ b/internal/bb.sh.tpl
@@ -15,7 +15,8 @@ done
 SCRIPT_DIR="$(cd -P "$( dirname "${SOURCE}" )" >/dev/null && pwd)"
 RAW_BINARY_PATH="$(realpath "${SCRIPT_DIR}/../%{raw_binary}")"
 
-#export CLJ_CONFIG=.clojure
-#export DEPS_CLJ_TOOLS_DIR=.deps.clj
+export CLJ_CONFIG="%{repo_root}/.clojure"
+export DEPS_CLJ_TOOLS_DIR="%{repo_root}/.deps.clj/ClojureTools"
+export GITLIBS="%{repo_root}/.gitlibs"
 
 "${RAW_BINARY_PATH}" "${@}"

--- a/releases.bzl
+++ b/releases.bzl
@@ -1,5 +1,13 @@
-RELEASES = {
+BABASHKA = {
     "babashka-1.3.184-macos-aarch64.tar.gz": "fe305da35fcd24035e88a54a4148c3213419c9c4a2f48be4fd443b9bc1730bc1",
     "babashka-1.3.184-macos-amd64.tar.gz": "12d522dbd73ca34f784ef3f5e3df16dd61fe348bca6a81f399d59fbcd7db448a",
     "babashka-1.3.184-linux-amd64.tar.gz": "41a529a9510a8b8b3d8383f56f4de17c570c22a1214548ac03a9f3055e63f714",
+}
+
+CLOJURE_TOOLS = {
+    "1.11.1.1403": "e40a5a330b7ed7ab9874ed4f6cd3062a97e20b7973e24f9c4772b2945b1ca68d",
+}
+
+TOOLS_MAPPING = {
+    "1.3.184": "1.11.1.1403",
 }


### PR DESCRIPTION
These are needed for certain commands, so we might as well grab them. Also set up env vars to keep all dependencies etc within the repo.