### PR TITLE
Add deps uberjar generation rule

### DIFF
--- a/BUILD.repo.tpl
+++ b/BUILD.repo.tpl
@@ -4,9 +4,15 @@ package(default_visibility=["//visibility:public"])
 
 exports_files(["%{raw_binary}", "%{wrapper}"])
 
+sh_binary(
+    name = "binary",
+    srcs = ["%{wrapper}"],
+    data = ["%{raw_binary}"],
+)
+
 babashka_toolchain(
     name = "toolchain_impl",
-    binary = "%{wrapper}"
+    binary = ":binary"
 )
 
 toolchain(

--- a/deps/deps.bzl
+++ b/deps/deps.bzl
@@ -1,0 +1,50 @@
+def _babashka_deps_jar_impl(ctx):
+    bb_toolchain = ctx.toolchains["@rules_babashka//toolchain:toolchain_type"].babashka
+    java_toolchain = ctx.toolchains["@bazel_tools//tools/jdk:runtime_toolchain_type"].java_runtime
+
+    ctx.actions.run(
+        inputs = java_toolchain.files.to_list() + [
+            ctx.file.bb_edn,
+            bb_toolchain.binary,
+        ],
+        outputs = [
+            ctx.outputs.output
+        ],
+        env = {
+            "JAVA_HOME": str(java_toolchain.java_home),
+        },
+        executable = bb_toolchain.binary,
+        arguments = [
+            "--config",
+            ctx.file.bb_edn.path,
+            "uberjar",
+            ctx.outputs.output.path,
+        ],
+    )
+
+_babashka_deps_jar = rule(
+    implementation = _babashka_deps_jar_impl,
+    toolchains = [
+        "@bazel_tools//tools/jdk:runtime_toolchain_type",
+        "@rules_babashka//toolchain:toolchain_type",
+    ],
+    attrs = {
+        "bb_edn": attr.label(
+            mandatory=True,
+            allow_single_file=True,
+            default="bb.edn"
+        ),
+        "output": attr.output(mandatory = True)
+    },
+)
+
+def babashka_deps_jar(**kwargs):
+    if kwargs.get("output"):
+        _babashka_deps_jar(
+            **kwargs,
+        )
+    else:
+        _babashka_deps_jar(
+            output = "{name}.jar".format(**kwargs),
+            **kwargs,
+        )

--- a/internal/bb.sh.tpl
+++ b/internal/bb.sh.tpl
@@ -19,4 +19,4 @@ export CLJ_CONFIG="%{repo_root}/.clojure"
 export DEPS_CLJ_TOOLS_DIR="%{repo_root}/.deps.clj/ClojureTools"
 export GITLIBS="%{repo_root}/.gitlibs"
 
-"${RAW_BINARY_PATH}" "${@}"
+"${RAW_BINARY_PATH}" -Sdeps "{:mvn/local-repo \"%{repo_root}/.m2/repository\"}" "${@}"

--- a/toolchain/toolchain.bzl
+++ b/toolchain/toolchain.bzl
@@ -1,14 +1,35 @@
-BabashkaToolchainInfo = provider(
+BabashkaInfo = provider(
     fields = {
         "binary": "path to the binary"
     }
 )
 
 def _babashka_toolchain_impl(ctx):
+    bb = ctx.files.binary[0]
+
+    default_info = DefaultInfo(
+        files = depset([bb]),
+        runfiles = ctx.runfiles([bb])
+    )
+
+    babashka_info = BabashkaInfo(
+        binary = bb
+    )
+
+    template_variables = platform_common.TemplateVariableInfo({
+        "BB": bb.path
+    })
+
+    toolchain_info = platform_common.ToolchainInfo(
+        babashka = babashka_info,
+        default = default_info,
+        template_variables = template_variables,
+    )
+
     return [
-        platform_common.ToolchainInfo(
-            binary = ctx.executable.binary
-        )
+        default_info,
+        toolchain_info,
+        template_variables,
     ]
 
 babashka_toolchain = rule(
@@ -16,9 +37,6 @@ babashka_toolchain = rule(
     attrs = {
         "binary": attr.label(
             mandatory=True,
-            executable=True,
-            allow_single_file=True,
-            cfg="host"
         )
     }
 )


### PR DESCRIPTION
This can replace a custom `genrule`, so you can just call `babashka_deps_jar` and get a jar file output.

Because we want it to run within a sandbox, it uses a local m2 repository dir instead of falling back to the system one (which it cannot write to). This is fine, because the process will only be re-run when the input `bb.edn` file changes.